### PR TITLE
Fix for https://issues.jenkins-ci.org/browse/JENKINS-8535 - do not fail grails builds with failing tests; fix for https://issues.jenkins-ci.org/browse/JENKINS-10266 - Set grails.work.dir to something unique by default

### DIFF
--- a/src/main/java/com/g2one/hudson/grails/GrailsBuilder.java
+++ b/src/main/java/com/g2one/hudson/grails/GrailsBuilder.java
@@ -328,7 +328,7 @@ public class GrailsBuilder extends Builder {
 class WrappedListener implements BuildListener {
 	private final BuildListener wrapped;
 	private PrintStream wrappedLogger;
-	private final MaxLengthList<String> consoleCache;
+	private final MaxLengthList<byte[]> consoleCache;
 
 //> CONSTRUCTORS
 	private WrappedListener(BuildListener listener) {
@@ -357,8 +357,9 @@ class WrappedListener implements BuildListener {
 	}
 
 	boolean isBuildFailingDueToFailingTests() {
-		for(String s : consoleCache) {
-			if(s.toLowerCase().contains("tests failed")) {
+		for(byte[] b : consoleCache) {
+			// TODO may need to explicitly set encoding here
+			if(new String(b).toLowerCase().contains("tests failed")) {
 				return true;
 			}
 		}
@@ -376,10 +377,10 @@ class WrappedListener implements BuildListener {
 
 class CachedPrintStream extends PrintStream {
 	private final PrintStream wrapped;
-	private final List<String> cache;
+	private final List<byte[]> cache;
 	private final BuildListener listener;
 
-	CachedPrintStream(PrintStream wrapped, List<String> cache, BuildListener listener) {
+	CachedPrintStream(PrintStream wrapped, List<byte[]> cache, BuildListener listener) {
 		super(wrapped);
 		this.wrapped = wrapped;
 		this.cache = cache;
@@ -389,7 +390,7 @@ class CachedPrintStream extends PrintStream {
 	// This appears to be the only method called on the Listener's logger.
 	// If others are called in future, we might need to decorate them as well.
 	public void write(byte[] buff, int off, int len) {
-		cache.add(new String(buff));
+		cache.add(buff);
 		super.write(buff, off, len);
 	}
 }

--- a/src/main/java/com/g2one/hudson/grails/GrailsBuilder.java
+++ b/src/main/java/com/g2one/hudson/grails/GrailsBuilder.java
@@ -195,6 +195,8 @@ public class GrailsBuilder extends Builder {
                 Map sytemProperties = new HashMap();
                 if (grailsWorkDir != null && !"".equals(grailsWorkDir.trim())) {
                     sytemProperties.put("grails.work.dir", evalTarget(env, grailsWorkDir.trim()));
+                } else {
+                    sytemProperties.put("grails.work.dir", build.getWorkspace().toURI().getPath() + "/target");
                 }
                 if (projectWorkDir != null && !"".equals(projectWorkDir.trim())) {
                     sytemProperties.put("grails.project.work.dir", evalTarget(env, projectWorkDir.trim()));

--- a/src/main/java/com/g2one/hudson/grails/GrailsBuilder.java
+++ b/src/main/java/com/g2one/hudson/grails/GrailsBuilder.java
@@ -7,19 +7,25 @@ import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Util;
+import hudson.console.ConsoleNote;
 import hudson.model.BuildListener;
 import hudson.model.AbstractBuild;
+import hudson.model.Cause;
 import hudson.model.Computer;
 import hudson.model.Descriptor;
 import hudson.model.Hudson;
+import hudson.model.Result;
 import hudson.tasks.Builder;
 import hudson.util.ArgumentListBuilder;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintStream;
+import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.LinkedList;
 import java.util.Map;
 
 import net.sf.json.JSONObject;
@@ -220,8 +226,11 @@ public class GrailsBuilder extends Builder {
                 }
 
                 try {
-                    int r = launcher.launch().cmds(args).envs(env).stdout(listener).pwd(getBasePath(build)).join();
-                    if (r != 0) return false;
+                    WrappedListener wrappedListener = WrappedListener.create(listener);
+                    int r = launcher.launch().cmds(args).envs(env).stdout(wrappedListener).pwd(getBasePath(build)).join();
+                    if (r != 0 && !wrappedListener.isBuildFailingDueToFailingTests()) {
+                        return false;
+                    }
                 } catch (IOException e) {
                     Util.displayIOException(e, listener);
                     e.printStackTrace(listener.fatalError("command execution failed"));
@@ -315,3 +324,88 @@ public class GrailsBuilder extends Builder {
         }
     }
 }
+
+class WrappedListener implements BuildListener {
+	private final BuildListener wrapped;
+	private PrintStream wrappedLogger;
+	private final MaxLengthList<String> consoleCache;
+
+//> CONSTRUCTORS
+	private WrappedListener(BuildListener listener) {
+		this.wrapped = listener;
+		this.consoleCache = new MaxLengthList(20);
+	}
+
+//> PASS THRUS TO WRAPPED LISTENER
+	public void started(List<Cause> causes) { wrapped.started(causes); }
+	public void finished(Result result) { wrapped.finished(result); }
+	public void annotate(ConsoleNote ann) throws IOException { wrapped.annotate(ann); }
+	public PrintWriter error(String msg) { return wrapped.error(msg); }
+	public PrintWriter error(String format, Object... args) { return wrapped.error(format, args); }
+	public PrintWriter fatalError(String msg) { return wrapped.fatalError(msg); }
+	public PrintWriter fatalError(String format, Object... args) { return wrapped.fatalError(format, args); }
+	public void hyperlink(String url, String text) throws IOException { wrapped.hyperlink(url, text); }
+
+//> CUSTOM METHODS AND OVERRIDES
+	public synchronized PrintStream getLogger() {
+		if(wrappedLogger == null) {
+			log("getLogger() :: wrapping logger...");
+			PrintStream realLogger = wrapped.getLogger();
+			wrappedLogger = new CachedPrintStream(realLogger, consoleCache, this);
+		}
+		return wrappedLogger;
+	}
+
+	boolean isBuildFailingDueToFailingTests() {
+		for(String s : consoleCache) {
+			if(s.toLowerCase().contains("tests failed")) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	static WrappedListener create(BuildListener listener) {
+		return new WrappedListener(listener);
+	}
+
+	private void log(String message) {
+		error("WrappedListener :: LOG :: " + message);
+	}
+}
+
+class CachedPrintStream extends PrintStream {
+	private final PrintStream wrapped;
+	private final List<String> cache;
+	private final BuildListener listener;
+
+	CachedPrintStream(PrintStream wrapped, List<String> cache, BuildListener listener) {
+		super(wrapped);
+		this.wrapped = wrapped;
+		this.cache = cache;
+		this.listener = listener;
+	}
+
+	// This appears to be the only method called on the Listener's logger.
+	// If others are called in future, we might need to decorate them as well.
+	public void write(byte[] buff, int off, int len) {
+		cache.add(new String(buff));
+		super.write(buff, off, len);
+	}
+}
+
+class MaxLengthList<E> extends LinkedList<E> {
+	private final int lengthLimit;
+
+	MaxLengthList(int lengthLimit) {
+		this.lengthLimit = lengthLimit;
+	}
+
+	public synchronized boolean add(E e) {
+		while(size() >= lengthLimit) {
+			removeFirst();
+		}
+		return super.add(e);
+	}
+}
+

--- a/src/main/resources/com/g2one/hudson/grails/GrailsBuilder/config.jelly
+++ b/src/main/resources/com/g2one/hudson/grails/GrailsBuilder/config.jelly
@@ -34,6 +34,7 @@
         <f:textbox name="grails.serverPort" value="${instance.serverPort}"/>
     </f:entry>
     <f:entry title="grails.work.dir"
+             help="${rootURL}/plugin/grails/help/projectConfig/grailsWorkDir.html"
              description="Specify a value for the grails.work.dir system property (optional)">
         <f:textbox name="grails.grailsWorkDir" value="${instance.grailsWorkDir}"/>
     </f:entry>

--- a/src/main/webapp/help/projectConfig/grailsWorkDir.html
+++ b/src/main/webapp/help/projectConfig/grailsWorkDir.html
@@ -1,0 +1,5 @@
+<div>
+	By default Grails projects wth the same `app.name` set in application.properties will share the
+	same directory for temporary files.  This creates a chance that concurrent builds of the same
+	project will cause inconsistent problems with that build.
+</div>


### PR DESCRIPTION
Does what it says on the tin:
1. allows JUnit reporter to mark builds which build but have failing tests as UNSTABLE vs STABLE, rather than them all being FAILED.
2. if no grails.work.dir is specified either thru jenkins settings or BuildConfig, will be set to $WORKSPACE/target.
