### PR TITLE
Misuse of local java.io.File

### DIFF
--- a/src/main/java/com/g2one/hudson/grails/GrailsBuilder.java
+++ b/src/main/java/com/g2one/hudson/grails/GrailsBuilder.java
@@ -1,6 +1,5 @@
 package com.g2one.hudson.grails;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -216,12 +215,12 @@ public class GrailsBuilder extends Builder {
                 if (grailsInstallation == null) {
                     args.add(execName);
                 } else {
-                    File exec = grailsInstallation.getExecutable();
-                    if (!new FilePath(launcher.getChannel(), grailsInstallation.getExecutable().getPath()).exists()) {
+                    FilePath exec = new FilePath(launcher.getChannel(), grailsInstallation.getHome()).child("bin").child(execName);
+                    if (!exec.exists()) {
                         listener.fatalError(exec + " doesn't exist");
                         return false;
                     }
-                    args.add(exec.getPath());
+                    args.add(exec.getRemote());
                 }
                 args.addKeyValuePairs("-D", build.getBuildVariables());
                 Map systemProperties = new HashMap();

--- a/src/main/java/com/g2one/hudson/grails/GrailsInstallation.java
+++ b/src/main/java/com/g2one/hudson/grails/GrailsInstallation.java
@@ -34,20 +34,6 @@ public final class GrailsInstallation extends ToolInstallation implements Enviro
         super(name, home, properties);
     }
 
-    public File getExecutable() {
-        String execName;
-        if (File.separatorChar == '\\')
-            execName = "grails.bat";
-        else
-            execName = "grails";
-
-        return new File(getHome(), "bin/" + execName);
-    }
-
-    public boolean getExists() {
-        return getExecutable().exists();
-    }
-
     public GrailsInstallation forNode(Node node, TaskListener log) throws IOException, InterruptedException {
         return new GrailsInstallation(getName(), translateFor(node, log), getProperties().toList());
     }


### PR DESCRIPTION
`GrailsInstallation.getExecutable` does not make sense in the context of distributed (slave) builds. `ToolInstallation.getHome` is a path on the slave node, so constructing a `java.io.File` from it in code run on the master is in general senseless—especially if master is Windows and the slave is Unix, or vice versa. Taking that `File.path` and using it on another machine might happen to work by accident but it cannot be guaranteed.

`getExists` is similarly meaningless, though it appears to be unused anyway.

Change tested successfully with Linux master and XP slave.
