### PR TITLE
[FIXED JENKINS-7702] Tomcat sometimes defines a $JAVA_OPTS inappropriate for subprocesses.

### DIFF
--- a/src/main/java/com/g2one/hudson/grails/GrailsBuilder.java
+++ b/src/main/java/com/g2one/hudson/grails/GrailsBuilder.java
@@ -31,6 +31,9 @@ import org.kohsuke.stapler.StaplerRequest;
 
 public class GrailsBuilder extends Builder {
 
+    private static final String JAVA_OPTS = "JAVA_OPTS";
+    private static final String JENKINS_7702_TRIGGER = "-Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager";
+
     private final String targets;
     private final String name;
     private String grailsWorkDir;
@@ -208,6 +211,13 @@ public class GrailsBuilder extends Builder {
                     .forNode(Computer.currentComputer().getNode(), listener);
                 env.put("GRAILS_HOME", grailsInstallation.getHome());
             }
+
+            String jopts = env.get(JAVA_OPTS);
+            if (jopts != null && jopts.contains(JENKINS_7702_TRIGGER)) {
+                listener.getLogger().println("[JENKINS-7702] sanitizing $" + JAVA_OPTS);
+                env.put(JAVA_OPTS, jopts.replace(JENKINS_7702_TRIGGER, "")); // leading/trailing spaces should be harmless
+            }
+
             for (String[] targetsAndArgs : targetsToRun) {
 
                 String target = targetsAndArgs[0];


### PR DESCRIPTION
Should fix the analogue of [JENKINS-7702](https://issues.jenkins-ci.org/browse/JENKINS-7702) for the Grails plugin. Probably need a similar fix for the Gradle plugin, and maybe even other plugins for other Java-related tools until the underlying [Tomcat bug](https://issues.apache.org/bugzilla/show_bug.cgi?id=54601) is addressed.
