### PR TITLE
Making getBasePath evaluate environment parameters

### DIFF
--- a/src/main/java/com/g2one/hudson/grails/GrailsBuilder.java
+++ b/src/main/java/com/g2one/hudson/grails/GrailsBuilder.java
@@ -191,7 +191,7 @@ public class GrailsBuilder extends Builder {
         if (targetsToRun.size() > 0) {
             String execName;
             if (useWrapper) {
-                FilePath wrapper = new FilePath(getBasePath(build), launcher.isUnix() ? "grailsw" : "grailsw.bat");
+                FilePath wrapper = new FilePath(getBasePath(build, env), launcher.isUnix() ? "grailsw" : "grailsw.bat");
                 execName = wrapper.getRemote();
             } else {
                 execName = launcher.isUnix() ? "grails" : "grails.bat";
@@ -263,7 +263,7 @@ public class GrailsBuilder extends Builder {
                 GrailsConsoleAnnotator gca = new GrailsConsoleAnnotator(listener.getLogger(), build.getCharset());
                 new GrailsTaskNote(target).encodeTo(listener.getLogger());
                 try {
-                    int r = launcher.launch().cmds(args).envs(env).stdout(gca).pwd(getBasePath(build)).join();
+                    int r = launcher.launch().cmds(args).envs(env).stdout(gca).pwd(getBasePath(build, env)).join();
                     if (r != 0) {
                         if (gca.isBuildFailingDueToFailingTests()) {
                             build.setResult(Result.UNSTABLE);
@@ -302,11 +302,11 @@ public class GrailsBuilder extends Builder {
         }
     }
 
-    private FilePath getBasePath(AbstractBuild<?, ?> build) {
+    private FilePath getBasePath(AbstractBuild<?, ?> build, EnvVars env) {
         FilePath basePath;
         FilePath moduleRoot = build.getModuleRoot();
         if (projectBaseDir != null && !"".equals(projectBaseDir.trim())) {
-            basePath = new FilePath(moduleRoot, projectBaseDir);
+            basePath = new FilePath(moduleRoot, eval(env, projectBaseDir));
         } else {
             basePath = moduleRoot;
         }


### PR DESCRIPTION
It was previously not possible (as far as I could tell) to parameterize the project base dir.
